### PR TITLE
settings plist references _settings

### DIFF
--- a/plugins/_check_timedrift.plist
+++ b/plugins/_check_timedrift.plist
@@ -12,7 +12,7 @@
 			<key>SettingStorageKey</key>
 			<string>.</string>
 			<key>SettingStoragePath</key>
-			<string>/Library/MonitoringClient/PluginSupport/_check_timedrift.plist</string>
+			<string>/Library/MonitoringClient/PluginSupport/_check_timedrift_settings.plist</string>
 			<key>SettingTitle</key>
 			<string>This plugin reports current NTP time drift</string>
 			<key>SettingTitleHint</key>
@@ -29,7 +29,7 @@
 			<key>SettingStorageKey</key>
 			<string>ntpServer</string>
 			<key>SettingStoragePath</key>
-			<string>/Library/MonitoringClient/PluginSupport/_check_timedrift.plist</string>
+			<string>/Library/MonitoringClient/PluginSupport/_check_timedrift_settings.plist</string>
 			<key>SettingTitle</key>
 			<string>NTP reference server</string>
 			<key>SettingTitleHint</key>
@@ -46,7 +46,7 @@
 			<key>SettingStorageKey</key>
 			<string>secondsOfAcceptableDrift</string>
 			<key>SettingStoragePath</key>
-			<string>/Library/MonitoringClient/PluginSupport/_check_timedrift.plist</string>
+			<string>/Library/MonitoringClient/PluginSupport/_check_timedrift_settings.plist</string>
 			<key>SettingTitle</key>
 			<string>Generate a warning when time drift is greater than X seconds</string>
 			<key>SettingTitleHint</key>

--- a/plugins/_check_timedrift.plugin
+++ b/plugins/_check_timedrift.plugin
@@ -9,7 +9,7 @@ ntpServer="time.apple.com"
 secondsOfAcceptableDrift=120
 
 # read prefpane settings & set defaults
-settings_plist='/Library/MonitoringClient/PluginSupport/_check_timedrift.plist'
+settings_plist='/Library/MonitoringClient/PluginSupport/_check_timedrift_settings.plist'
 
 if [ ! -f $settings_plist ]; then
 	# populate plist with defaults


### PR DESCRIPTION
this updates the timedrift plugin, I haven't checked the other plugins.

There is an issue with this not being visible in the PreferencePane, since `sudo defaults write` creates plists which are `chmod 600`, so the PreferencePane, which is running as the console user, can't see the settings until after our agent has wrong.

You could create a loop of "if writing, also chmod 644"