### PR TITLE
fix reference to plugin's settings path

### DIFF
--- a/Plugins/macOS/_check_munki_installs/_check_munki_installs.plist
+++ b/Plugins/macOS/_check_munki_installs/_check_munki_installs.plist
@@ -14,7 +14,7 @@
         <key>SettingStorageKey</key>
         <string>.</string>
         <key>SettingStoragePath</key>
-        <string>/Library/MonitoringClient/PluginSupport/_check_munki_installs.plist</string>
+        <string>/Library/MonitoringClient/PluginSupport/_check_munki_installs_settings.plist</string>
         <key>SettingTitle</key>
         <string>Report the last 30 days of munki installs</string>
         <key>SettingTitleHint</key>
@@ -31,7 +31,7 @@
         <key>SettingStorageKey</key>
         <string>ignoreInstalls</string>
         <key>SettingStoragePath</key>
-        <string>/Library/MonitoringClient/PluginSupport/_check_munki_installs.plist</string>
+        <string>/Library/MonitoringClient/PluginSupport/_check_munki_installs_settings.plist</string>
         <key>SettingTitle</key>
         <string>Ignore installs that match...</string>
         <key>SettingTitleHint</key>

--- a/Plugins/macOS/_check_munki_installs/_check_munki_installs.plugin
+++ b/Plugins/macOS/_check_munki_installs/_check_munki_installs.plugin
@@ -15,7 +15,7 @@ from PluginToolkit import writePlist
 from PluginToolkit import check_settings
 
 # read preferences
-settings_plist = '/Library/MonitoringClient/PluginSupport/_check_munki_installs.plist'
+settings_plist = '/Library/MonitoringClient/PluginSupport/_check_munki_installs_settings.plist'
 base_settings = {
     'ignoreInstalls' : '',
     'PrefPaneVisibility' : True,


### PR DESCRIPTION
The PreferencePane looks for a settings file at

 ` [pluginName stringByAppendingString:@"_settings.plist"];`

The lack of the _settings convention is what prevented the preferencepane from showing the settings.

If there's valuable content in the settings file, it would be good to script a 

```
cp /Library/MonitoringClient/PluginSupport/_check_munki_installs.plist' /Library/MonitoringClient/PluginSupport/_check_munki_installs_settings.plist'
```
before deploying this change