### PR TITLE
Normalize plist files

### DIFF
--- a/Plugins/macOS/_check_interfaces/_check_interfaces.plist
+++ b/Plugins/macOS/_check_interfaces/_check_interfaces.plist
@@ -35,7 +35,7 @@
         <key>SettingTitle</key>
         <string>Network Service to monitor</string>
         <key>SettingTitleHint</key>
-			<string>Provide the exact Network Service name you want to monitor as listed within System Preferences -&gt; Network</string>
+            <string>Provide the exact Network Service name you want to monitor as listed within System Preferences -&gt; Network</string>
         <key>SettingType</key>
         <dict>
           <key>Type</key>

--- a/Plugins/macOS/_check_interfaces/_check_interfaces.plist
+++ b/Plugins/macOS/_check_interfaces/_check_interfaces.plist
@@ -35,7 +35,7 @@
         <key>SettingTitle</key>
         <string>Network Service to monitor</string>
         <key>SettingTitleHint</key>
-        <string>Provide the exact Network Service name you want to monitor as listed within System Preferences -> Network</string>
+			<string>Provide the exact Network Service name you want to monitor as listed within System Preferences -&gt; Network</string>
         <key>SettingType</key>
         <dict>
           <key>Type</key>

--- a/Plugins/macOS/_check_mdm/_check_mdm.plist
+++ b/Plugins/macOS/_check_mdm/_check_mdm.plist
@@ -14,7 +14,7 @@
             <key>SettingStoragePath</key>
             <string>/Library/MonitoringClient/PluginSupport/_check_mdm_settings.plist</string>
             <key>SettingTitle</key>
-            <string>Alerts if MDM isn't installed.</string>
+			<string>Alerts if MDM isn&apos;t installed.</string>
             <key>SettingTitleHint</key>
             <string>None: Will only notify Watchman. Warn: Watchman will send an email once. Alert: Watchman will continue to send email alerts.</string>
             <key>SettingType</key>
@@ -34,7 +34,7 @@
             <string>uamdm_warning</string>
             <key>SettingStoragePath</key> 			<string>/Library/MonitoringClient/PluginSupport/_check_mdm_settings.plist</string>
             <key>SettingTitle</key>
-            <string>Alerts if MDM isn't approved (10.13.4+ only.)</string>
+			<string>Alerts if MDM isn&apos;t approved (10.13.4+ only.)</string>
             <key>SettingTitleHint</key>
             <string>None: Will only notify Watchman. Warn: Watchman will send an email once. Alert: Watchman will continue to send email alerts.</string>
             <key>SettingType</key>

--- a/Plugins/macOS/_check_mdm/_check_mdm.plist
+++ b/Plugins/macOS/_check_mdm/_check_mdm.plist
@@ -14,7 +14,7 @@
             <key>SettingStoragePath</key>
             <string>/Library/MonitoringClient/PluginSupport/_check_mdm_settings.plist</string>
             <key>SettingTitle</key>
-			<string>Alerts if MDM isn&apos;t installed.</string>
+            <string>Alerts if MDM isn&apos;t installed.</string>
             <key>SettingTitleHint</key>
             <string>None: Will only notify Watchman. Warn: Watchman will send an email once. Alert: Watchman will continue to send email alerts.</string>
             <key>SettingType</key>
@@ -35,7 +35,7 @@
             <key>SettingStoragePath</key>
             <string>/Library/MonitoringClient/PluginSupport/_check_mdm_settings.plist</string>
             <key>SettingTitle</key>
-			<string>Alerts if MDM isn&apos;t approved (10.13.4+ only.)</string>
+            <string>Alerts if MDM isn&apos;t approved (10.13.4+ only.)</string>
             <key>SettingTitleHint</key>
             <string>None: Will only notify Watchman. Warn: Watchman will send an email once. Alert: Watchman will continue to send email alerts.</string>
             <key>SettingType</key>

--- a/Plugins/macOS/_check_mdm/_check_mdm.plist
+++ b/Plugins/macOS/_check_mdm/_check_mdm.plist
@@ -32,7 +32,8 @@
         <dict>
             <key>SettingStorageKey</key>
             <string>uamdm_warning</string>
-            <key>SettingStoragePath</key> 			<string>/Library/MonitoringClient/PluginSupport/_check_mdm_settings.plist</string>
+            <key>SettingStoragePath</key>
+            <string>/Library/MonitoringClient/PluginSupport/_check_mdm_settings.plist</string>
             <key>SettingTitle</key>
 			<string>Alerts if MDM isn&apos;t approved (10.13.4+ only.)</string>
             <key>SettingTitleHint</key>

--- a/Plugins/macOS/_check_munki_manifest_link/_check_munki_manifest_link.plist
+++ b/Plugins/macOS/_check_munki_manifest_link/_check_munki_manifest_link.plist
@@ -6,8 +6,8 @@
 	<string>Munki Manifest</string>
 	<key>PluginVersion</key>
 	<string>1.0.2</string>
-  <key>PluginUUID</key>
-  <string>4c9d30bd-32eb-4189-bbc9-cad411e0b5f2</string>
+	<key>PluginUUID</key>
+	<string>4c9d30bd-32eb-4189-bbc9-cad411e0b5f2</string>
 	<key>PluginOptions</key>
 	<array>
 		<dict>

--- a/Plugins/macOS/_check_munkireport_link/_check_munkireport_link.plist
+++ b/Plugins/macOS/_check_munkireport_link/_check_munkireport_link.plist
@@ -6,8 +6,8 @@
 	<string>MunkiReport</string>
 	<key>PluginVersion</key>
 	<string>2.0.2</string>
-  <key>PluginUUID</key>
-  <string>50a3bbaa-00f0-486a-9aac-dadd0363342e</string>
+	<key>PluginUUID</key>
+	<string>50a3bbaa-00f0-486a-9aac-dadd0363342e</string>
 	<key>PluginOptions</key>
 	<array>
 		<dict>

--- a/Plugins/macOS/_check_swap/_check_swap.plist
+++ b/Plugins/macOS/_check_swap/_check_swap.plist
@@ -6,8 +6,8 @@
 	<string>Swap Usage</string>
 	<key>PluginVersion</key>
 	<string>1.0</string>
-  <key>PluginUUID</key>
-  <string>37C0B784-D15C-4DB3-91B7-49C4CC3DD121</string>
+	<key>PluginUUID</key>
+	<string>37C0B784-D15C-4DB3-91B7-49C4CC3DD121</string>
 	<key>PluginOptions</key>
 	<array>
 		<dict>

--- a/Plugins/macOS/_check_timedrift/_check_timedrift.plist
+++ b/Plugins/macOS/_check_timedrift/_check_timedrift.plist
@@ -6,8 +6,8 @@
 	<string>Time Drift</string>
 	<key>PluginVersion</key>
 	<string>1.5</string>
-  <key>PluginUUID</key>
-  <string>3AE09BDE-D2D7-4804-9B43-650DE08BA01E</string>
+	<key>PluginUUID</key>
+	<string>3AE09BDE-D2D7-4804-9B43-650DE08BA01E</string>
 	<key>PluginOptions</key>
 	<array>
 		<dict>
@@ -44,7 +44,7 @@
 				<string></string>
 			</dict>
 		</dict>
-    <dict>
+	<dict>
 			<key>SettingStorageKey</key>
 			<string>secondsOfAcceptableDrift</string>
 			<key>SettingStoragePath</key>
@@ -61,7 +61,7 @@
 				<string>0-300</string>
 			</dict>
 		</dict>
-    <dict>
+	<dict>
 			<key>SettingStorageKey</key>
 			<string>attemptRemediation</string>
 			<key>SettingStoragePath</key>


### PR DESCRIPTION
Normalizing the plist files helped find & validate the UUIDs in the plugins

![image](https://github.com/sphen13/watchman-monitoring-plugins/assets/2879972/786e5e3b-1338-4736-851a-42d756e7270f)
